### PR TITLE
Add support for Floating IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 			./pkg/internal/compare
 
 integration:
-	K8TEST_PATH=${PWD}/k8test go test -count=1 -tags=integration ./pkg/internal/integration -v
+	K8TEST_PATH=${PWD}/k8test go test -count=1 -tags=integration ./pkg/internal/integration -v -timeout 30m
 
 coverage: test
 	go tool cover -html=cover.out

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ kind: Service
 metadata:
   annotations:
     k8s.cloudscale.ch/loadbalancer-listener-allowed-cidrs: '["1.2.3.0/24"]'
+    k8s.cloudscale.ch/loadbalancer-floating-ips: '["1.2.3.4/32"]'
 ```
 
 The full set of configuration toggles can be found in the [`pkg/cloudscale_ccm/loadbalancer.go`](pkg/cloudscale/ccm/loadbalancer.go) file.

--- a/examples/nginx-hello.yml
+++ b/examples/nginx-hello.yml
@@ -4,13 +4,13 @@
 #     export KUBECONFIG=path/to/kubeconfig
 #     kubectl apply -f nginx-hello.yml
 #
-# Wait for `kubectl describe hello` to show "Loadbalancer Ensured", then
-# use the IP address found under "LoadBalancer Ingress" to connect to the
+# Wait for `kubectl describe service hello` to show "Loadbalancer Ensured",
+# then use the IP address found under "LoadBalancer Ingress" to connect to the
 # service.
 #
 # You can also use the following shortcut:
 #
-#     curl http://$(kubectl get service hello -o json | jq -r '.status.loadBalancer.ingress[0].ip')
+#     curl http://$(kubectl get service hello -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 #
 ---
 apiVersion: apps/v1

--- a/examples/nginx-hello.yml
+++ b/examples/nginx-hello.yml
@@ -1,0 +1,57 @@
+# Deploys the nginxdemos/hello:plain-text container and creates a
+# loadbalancer service for it:
+#
+#     export KUBECONFIG=path/to/kubeconfig
+#     kubectl apply -f nginx-hello.yml
+#
+# Wait for `kubectl describe hello` to show "Loadbalancer Ensured", then
+# use the IP address found under "LoadBalancer Ingress" to connect to the
+# service.
+#
+# You can also use the following shortcut:
+#
+#     curl http://$(kubectl get service hello -o json | jq -r '.status.loadBalancer.ingress[0].ip')
+#
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+    spec:
+      containers:
+      - name: hello
+        image: nginxdemos/hello:plain-text
+
+      # Spread the containers across nodes
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app: hello
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello
+  name: hello
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+    name: primary
+  selector:
+    app: hello
+  type: LoadBalancer

--- a/pkg/cloudscale_ccm/reconcile_test.go
+++ b/pkg/cloudscale_ccm/reconcile_test.go
@@ -231,6 +231,9 @@ func TestActualState(t *testing.T) {
 			},
 		},
 	)
+	server.On("/v1/floating-ips", 200,
+		[]cloudscale.FloatingIP{},
+	)
 	server.Start()
 	defer server.Close()
 

--- a/pkg/cloudscale_ccm/service_info.go
+++ b/pkg/cloudscale_ccm/service_info.go
@@ -86,6 +86,8 @@ func (s serviceInfo) annotation(key string) string {
 		return s.annotationOrDefault(key, "lb-standard")
 	case LoadBalancerVIPAddresses:
 		return s.annotationOrDefault(key, "[]")
+	case LoadBalancerFloatingIPs:
+		return s.annotationOrDefault(key, "[]")
 	case LoadBalancerPoolAlgorithm:
 		return s.annotationOrDefault(key, "round_robin")
 	case LoadBalancerHealthMonitorDelayS:

--- a/pkg/internal/actions/actions.go
+++ b/pkg/internal/actions/actions.go
@@ -562,3 +562,31 @@ func (a *UpdateMonitorNumberAction) Run(
 	return ProceedOnSuccess(
 		client.LoadBalancerHealthMonitors.Update(ctx, a.monitorUUID, &req))
 }
+
+// AssignFloatingIP assigns a Floating IP to the given LoadBalancer UUID
+type AssignFloatingIPAction struct {
+	ip     string
+	lbUUID string
+}
+
+func AssignFloatingIP(ip string, lbUUID string) Action {
+	return &AssignFloatingIPAction{ip: ip, lbUUID: lbUUID}
+}
+
+func (a *AssignFloatingIPAction) Label() string {
+	return fmt.Sprintf("assign-floating-ip(%s -> %s)", a.ip, a.lbUUID)
+}
+
+func (a *AssignFloatingIPAction) Run(
+	ctx context.Context, client *cloudscale.Client) (Control, error) {
+
+	ip := strings.SplitN(a.ip, "/", 2)[0]
+
+	err := client.FloatingIPs.Update(
+		ctx, ip, &cloudscale.FloatingIPUpdateRequest{
+			LoadBalancer: a.lbUUID,
+		},
+	)
+
+	return ProceedOnSuccess(err)
+}

--- a/pkg/internal/actions/actions_test.go
+++ b/pkg/internal/actions/actions_test.go
@@ -514,3 +514,24 @@ func TestUpdateMonitorNumberAction(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, Errored, v)
 }
+
+func TestAssignFloatingIPAction(t *testing.T) {
+	server := testkit.NewMockAPIServer()
+	server.On("/v1/floating-ips/100.1.1.1", 201, "{}")
+	server.Start()
+	defer server.Close()
+
+	action := AssignFloatingIP(
+		"100.1.1.1/24", "00000000-0000-0000-0000-000000000000")
+
+	assert.NotEmpty(t, action.Label())
+	v, err := action.Run(context.Background(), server.Client())
+
+	assert.NoError(t, err)
+	assert.Equal(t, Proceed, v)
+
+	var sent cloudscale.FloatingIPUpdateRequest
+	server.LastSent(&sent)
+
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", sent.LoadBalancer)
+}


### PR DESCRIPTION
Using annotations, the load balancer can have floating IPs assigned to it. To avoid flapping, the code ensures that these IPs are not assigned to multiple services inside the same cluster.