### PR TITLE
Fix CCM creating LBs ad infinitum, when encountering a missing UUID

### DIFF
--- a/helpers/run-in-test-cluster
+++ b/helpers/run-in-test-cluster
@@ -19,16 +19,16 @@ function ensure-k8test() {
   # on the runners and cloning via SSH does not work.
   #
   # Therefore we run a separate install block that is only meant for GitHub.
-  if [[ "${GITHUB_ACTIONS:-}" == "true" ]] then
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
     if test -d k8test; then
-      source k8test/venv/bin/activate 
+      source k8test/venv/bin/activate
       return
     fi
 
     mkdir -p ~/.ssh/ && touch ~/.ssh/known_hosts
     git clone https://github.com/cloudscale-ch/k8test
     python3 -m venv k8test/venv
-    source k8test/venv/bin/activate 
+    source k8test/venv/bin/activate
     pip install poetry
     poetry install --directory k8test
     return
@@ -74,7 +74,7 @@ function ensure-cluster() {
   if ! test -f k8test/cluster/ssh.pub; then
     ssh-keygen -t ed25519 -N '' -f k8test/cluster/ssh
   fi
- 
+
   if ! test -f k8test/cluster/admin.conf; then
     zone="$(random-zone)"
 
@@ -107,7 +107,7 @@ function ensure-cluster() {
       -e kubelet_extra_args='--cloud-provider=external' \
       -e kubernetes="${KUBERNETES}" \
       -e cluster_prefix="${CLUSTER_PREFIX}" \
-      -e subnet="${SUBNET}"    
+      -e subnet="${SUBNET}"
   fi
 }
 

--- a/pkg/cloudscale_ccm/loadbalancer.go
+++ b/pkg/cloudscale_ccm/loadbalancer.go
@@ -21,12 +21,11 @@ import (
 // them, unless you know what you are doing.
 const (
 	// LoadBalancerUUID uniquely identifes the loadbalancer. This annotation
-	// should not be provided by the customer, unless the adoption of an
-	// existing load balancer is desired.
+	// should not be provided by the customer.
 	//
-	// In all other cases, this value is set by the CCM after creating the
-	// load balancer, to ensure that we track it with a proper ID and not
-	// a name that might change without our knowledge.
+	// Instead, this value is set by the CCM after creating the load balancer,
+	// to ensure that we track it with a proper ID and not a name that might
+	// change without our knowledge.
 	LoadBalancerUUID = "k8s.cloudscale.ch/loadbalancer-uuid"
 
 	// LoadBalancerConfigVersion is set by the CCM when it first handles a

--- a/pkg/internal/limiter/limiter.go
+++ b/pkg/internal/limiter/limiter.go
@@ -18,6 +18,52 @@ func New[T any](err error, elements ...T) *Limiter[T] {
 	}
 }
 
+func Join[T any](limiters ...*Limiter[T]) *Limiter[T] {
+	joined := &Limiter[T]{
+		Error:    nil,
+		elements: []T{},
+	}
+
+	for _, limiter := range limiters {
+
+		// Keep the first error
+		if joined.Error != nil && limiter.Error != nil {
+			joined.Error = limiter.Error
+		}
+
+		// Append the elements
+		joined.elements = append(joined.elements, limiter.elements...)
+	}
+
+	return joined
+}
+
+// Unique excludes duplicate elements, according to a comparison function.
+// This is meant for small lists as the complexity is O(n^2).
+func (t *Limiter[T]) Unique(eq func(a *T, b *T) bool) *Limiter[T] {
+	result := []T{}
+
+	for _, a := range t.elements {
+		add := true
+
+		for _, b := range result {
+			if eq(&a, &b) {
+				add = false
+
+				break
+			}
+		}
+
+		if add {
+			result = append(result, a)
+		}
+	}
+
+	t.elements = result
+
+	return t
+}
+
 // All returns the full set of answers.
 func (t *Limiter[T]) All() ([]T, error) {
 	if t.Error != nil {
@@ -67,4 +113,13 @@ func (t *Limiter[T]) AtMostOne() (*T, error) {
 	}
 
 	return &t.elements[0], nil
+}
+
+// Count returns the number of elements, if there is no error.
+func (t *Limiter[T]) Count() int {
+	if t.Error != nil {
+		return 0
+	}
+
+	return len(t.elements)
 }


### PR DESCRIPTION
When the k8s.cloudscale.ch/loadbalancer-uuid annotation was present on
a service, but the UUID could not be found in via API, the CCM would
start creating LBs in a loop until it was killed.

The cause of this was the LBs were looked up. The CCM aassumed that if
a UUID could not be found, that the LB must not exist, and tried to
create one. This would happen in a loop without any way for the CCM to
detect that it should stop.

This assumption has now been changed. We now check for the LB both by
name and UUID, and expect to find at most one. If the service name and
the UUID both match different LBs (as might happen if one manipulates
the service annotations manually), the CCM will return an error.

Ultimately, the CCM has no state it can call its own and infers
state from the APIs it talks to (i.e., Kubernetes and the cloudscale.ch
API).

So if someone were to change both the UUID and the name of the LB using
annotations, the CCM would have no choice but to create a new LB.

Manipulating the UUID was at one point thought to be a possible feature:

One could bring an existing LB into the managament of the CCM. Though
there is no code that would prevent this, the docs no longer mention
this option, as this has the potential to cause havoc.

Changing the name is already discouraged. It is probably savest to
not touch the name, nor the UUID, during the lifetime of a service.